### PR TITLE
Handle null nodes without failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function (vnode) {
   var result = {}
 
   function parser (res, vnode) {
-    if (vnode == null) return
+    if (vnode == null) return res
     var attrs = vnode.attrs || {}
 
     function append (name, value) {

--- a/test/input.js
+++ b/test/input.js
@@ -56,3 +56,20 @@ test('ignore null value', function (t) {
 
   t.end()
 })
+
+test('ignore null value', function (t) {
+  t.deepEqual(
+    formParser(
+      m('div', [
+        m('input', { name: 'field1', value: 1 }),
+        null,
+        m('input', { name: 'field2', value: 2 })
+      ])),
+    {
+      field1: 1,
+      field2: 2
+    }
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Bugfix to let the form parser handle nodes which are null. Previously it would break when a node was null (but not []), since the parser would return undefined instead of the res object.

I've added a test to replicate the error.